### PR TITLE
Fix parse error when .sqliterc option is '.timer ON'

### DIFF
--- a/lib/migr8.rb
+++ b/lib/migr8.rb
@@ -853,13 +853,15 @@ END
       PATTERN = /\bsqlite3\b/
 
       def execute_sql(sql, cmdopt=nil)
-        preamble = ".bail ON\n"
         return super(preamble+sql, cmdopt)
       end
 
       def run_sql(sql, opts={})
-        preamble = ".bail ON\n"
         super(preamble+sql, opts)
+      end
+
+      def preamble
+        ".bail ON\n" + ".timer OFF\n"
       end
 
       protected


### PR DESCRIPTION
When `.sqliterc` option is `.timer ON`

```
migr8.rb:749:in `block in _get_migrations': undefined method `strip' for nil:NilClass (NoMethodError)
	from migr8/lib/migr8.rb:745:in `each_line'
	from migr8/lib/migr8.rb:745:in `_get_migrations'
```

Added `.timer OFF` to preamble.